### PR TITLE
chore: add the detail field to the image_url just like Midscene does

### DIFF
--- a/connectivity-test/package.json
+++ b/connectivity-test/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "test": "vitest ./tests/connectivity.test.ts"
+        "test": "vitest run ./tests/connectivity.test.ts"
     },
     "author": "",
     "license": "MIT",

--- a/connectivity-test/tests/connectivity.test.ts
+++ b/connectivity-test/tests/connectivity.test.ts
@@ -61,6 +61,7 @@ describe("Use OpenAI SDK directly", () => {
               type: "image_url",
               image_url: {
                 url: imageBase64,
+                detail: 'high'
               },
             },
           ],
@@ -88,6 +89,7 @@ describe("Use Midscene wrapped OpenAI SDK", () => {
               type: "image_url",
               image_url: {
                 url: imageBase64,
+                detail: 'high'
               },
             },
           ],


### PR DESCRIPTION
Some model forwarding services may lose the "detail" field. Which will cause the model config can pass the connection test but failed in Midscene.