### PR TITLE
docs(android): replace keyboardDismissStrategy with autoDismissKeyboard: false

### DIFF
--- a/android/javascript-sdk-demo/demo.ts
+++ b/android/javascript-sdk-demo/demo.ts
@@ -10,9 +10,9 @@ Promise.resolve(
   (async () => {
     const devices = await getConnectedDevices();
     const page = new AndroidDevice(devices[0].udid, {
-      // 👀 Use 'back-first' to avoid ESCAPE key side-effects in WebView / Mobile web pages
-      // The default 'esc-first' may close popups or clear input fields in WebView
-      keyboardDismissStrategy: 'back-first',
+      // 👀 Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+      // Some input fields listen for ESCAPE or BACK key events and may clear the input
+      autoDismissKeyboard: false,
     });
 
     // 👀 init Midscene agent

--- a/android/javascript-sdk-demo/demo.ts
+++ b/android/javascript-sdk-demo/demo.ts
@@ -12,6 +12,7 @@ Promise.resolve(
     const page = new AndroidDevice(devices[0].udid, {
       // 👀 Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
       // Some input fields listen for ESCAPE or BACK key events and may clear the input
+      // See: https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing
       autoDismissKeyboard: false,
     });
 

--- a/android/vitest-demo/tests/todo.test.ts
+++ b/android/vitest-demo/tests/todo.test.ts
@@ -21,6 +21,7 @@ describe('Test todo list', () => {
     const devices = await getConnectedDevices();
     const page = new AndroidDevice(devices[0].udid, {
       // Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+      // See: https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing
       autoDismissKeyboard: false,
     });
     agent = new AndroidAgent(page, {

--- a/android/vitest-demo/tests/todo.test.ts
+++ b/android/vitest-demo/tests/todo.test.ts
@@ -20,8 +20,8 @@ describe('Test todo list', () => {
   beforeAll(async () => {
     const devices = await getConnectedDevices();
     const page = new AndroidDevice(devices[0].udid, {
-      // Use 'back-first' to avoid ESCAPE key side-effects in WebView / Mobile web pages
-      keyboardDismissStrategy: 'back-first',
+      // Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+      autoDismissKeyboard: false,
     });
     agent = new AndroidAgent(page, {
       aiActContext:

--- a/android/yaml-scripts-demo/midscene-scripts/maps-navigation.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/maps-navigation.yaml
@@ -2,6 +2,7 @@ android:
   # launch: https://www.ebay.com
   deviceId: s4ey59ytbitot4yp
   # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  # See: https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing
   autoDismissKeyboard: false
 
 tasks:

--- a/android/yaml-scripts-demo/midscene-scripts/maps-navigation.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/maps-navigation.yaml
@@ -1,8 +1,8 @@
 android:
   # launch: https://www.ebay.com
   deviceId: s4ey59ytbitot4yp
-  # Use 'back-first' to avoid ESCAPE key side-effects in WebView / Mobile web pages
-  keyboardDismissStrategy: back-first
+  # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  autoDismissKeyboard: false
 
 tasks:
   - name: travel

--- a/android/yaml-scripts-demo/midscene-scripts/search-headphone-on-ebay.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/search-headphone-on-ebay.yaml
@@ -3,8 +3,8 @@
 android:
   launch: https://www.ebay.com
   deviceId: s4ey59ytbitot4yp
-  # Use 'back-first' to avoid ESCAPE key side-effects in WebView / Mobile web pages
-  keyboardDismissStrategy: back-first
+  # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  autoDismissKeyboard: false
 
 tasks:
   - name: search headphones

--- a/android/yaml-scripts-demo/midscene-scripts/search-headphone-on-ebay.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/search-headphone-on-ebay.yaml
@@ -4,6 +4,7 @@ android:
   launch: https://www.ebay.com
   deviceId: s4ey59ytbitot4yp
   # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  # See: https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing
   autoDismissKeyboard: false
 
 tasks:

--- a/android/yaml-scripts-demo/midscene-scripts/twitter-auto-like.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/twitter-auto-like.yaml
@@ -1,6 +1,7 @@
 android:
   deviceId: s4ey59ytbitot4yp
   # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  # See: https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing
   autoDismissKeyboard: false
 
 tasks:

--- a/android/yaml-scripts-demo/midscene-scripts/twitter-auto-like.yaml
+++ b/android/yaml-scripts-demo/midscene-scripts/twitter-auto-like.yaml
@@ -1,7 +1,7 @@
 android:
   deviceId: s4ey59ytbitot4yp
-  # Use 'back-first' to avoid ESCAPE key side-effects in WebView / Mobile web pages
-  keyboardDismissStrategy: back-first
+  # Disable auto keyboard dismiss to avoid ESCAPE/BACK key side-effects in WebView / Mobile web pages
+  autoDismissKeyboard: false
 
 tasks:
   - name: like tweets


### PR DESCRIPTION
## Summary

- Replace `keyboardDismissStrategy: 'back-first'` with `autoDismissKeyboard: false` in all Android examples
- This avoids both ESC and BACK key side-effects that can clear input fields in WebView / mobile web pages
- For more details on the text input issue and alternative solutions, see the [Android FAQ — Text input is cleared or lost after typing](https://midscenejs.com/android-getting-started.html#text-input-is-cleared-or-lost-after-typing)

## Changed files

- `android/javascript-sdk-demo/demo.ts`
- `android/vitest-demo/tests/todo.test.ts`
- `android/yaml-scripts-demo/midscene-scripts/twitter-auto-like.yaml`
- `android/yaml-scripts-demo/midscene-scripts/maps-navigation.yaml`
- `android/yaml-scripts-demo/midscene-scripts/search-headphone-on-ebay.yaml`

## Test plan

- [ ] Verify Android examples still run correctly with the new configuration