### PR TITLE
feat(computer): add rdp demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test-results/
 .env
 
 output/
+docs/
 
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Here are some examples you can refer to:
 - [Vitest Demo](./android/vitest-demo/): Integrate Midscene with Android and Vitest.
 - [YAML Scripts Demo](./android/yaml-scripts-demo/): Automate Android with scripts in YAML. This is the easiest way to integrate Midscene with your existing Android project.
 
+### Computer
+- [JavaScript SDK Demo](./computer/javascript-sdk-demo/): Integrate Midscene with your local desktop through `@midscene/computer`.
+- [Vitest Demo](./computer/vitest-demo/): Integrate Midscene with `@midscene/computer` and Vitest.
+- [Electron Demo](./computer/electron-demo/): Use Midscene with an Electron app.
+- [YAML Scripts Demo](./computer/yaml-scripts-demo/): Automate desktop tasks with scripts in YAML.
+- [RDP Demo](./computer/rdp-demo/): Control a remote Windows desktop directly over the RDP protocol.
+
 ## Connectivity Test
 
 - [Connectivity Test](./connectivity-test/): Use this folder to test the connectivity of the LLM Service.

--- a/computer/rdp-demo/README.md
+++ b/computer/rdp-demo/README.md
@@ -1,0 +1,55 @@
+# Computer RDP Demo
+
+This demo shows how to use `@midscene/computer` to control a remote Windows desktop directly over the RDP protocol.
+
+## Steps
+
+### Preparation
+
+Create `.env` file with the same Midscene model variables used by other examples:
+
+```shell
+MIDSCENE_MODEL_BASE_URL="https://.../compatible-mode/v1"
+MIDSCENE_MODEL_API_KEY="sk-abcdefghijklmnopqrstuvwxyz"
+MIDSCENE_MODEL_NAME="qwen3-vl-plus"
+MIDSCENE_MODEL_FAMILY="qwen3-vl"
+```
+
+Then open [demo.ts](./demo.ts) and update the placeholder values in the `rdpTarget` object:
+
+```ts
+const rdpTarget = {
+  host: 'REPLACE_WITH_YOUR_RDP_HOST',
+  port: 3389,
+  username: 'Admin',
+  password: 'REPLACE_WITH_YOUR_RDP_PASSWORD',
+  ignoreCertificate: true,
+  adminSession: false,
+  domain: undefined,
+  securityProtocol: 'auto',
+};
+```
+
+The demo validates the RDP target values before creating the agent. If you leave a placeholder unchanged, it will throw immediately.
+
+If you want to use another model, refer to:
+https://midscenejs.com/model-common-config.html
+
+### Run demo
+
+```bash
+npm install
+
+npm run test
+```
+
+The demo will connect to the remote Windows desktop, wait for the remote framebuffer to become visible if the first frame is blank, open the Settings app, continue into the Windows Update page, read the visible page title and status summary back into structured JSON, and print the generated report path. Each run creates a unique timestamped report file so old failures do not get mixed into the latest result.
+
+## Notes
+
+- This demo uses protocol-level RDP control. Midscene sees the remote Windows framebuffer directly instead of controlling a local RDP client window.
+
+## Reference
+
+- https://midscenejs.com/computer-introduction.html
+- https://midscenejs.com/computer-api-reference.html

--- a/computer/rdp-demo/README.md
+++ b/computer/rdp-demo/README.md
@@ -43,7 +43,7 @@ npm install
 npm run test
 ```
 
-The demo will connect to the remote Windows desktop, wait for the remote framebuffer to become visible if the first frame is blank, open the Settings app, continue into the Windows Update page, read the visible page title and status summary back into structured JSON, and print the generated report path. Each run creates a unique timestamped report file so old failures do not get mixed into the latest result.
+The demo will connect to the remote Windows desktop, wait for the remote framebuffer to become visible if the first frame is blank, open the Settings app, continue into the Windows Update page, read the visible page title and status summary back into structured JSON, and print the generated report path.
 
 ## Notes
 

--- a/computer/rdp-demo/demo.ts
+++ b/computer/rdp-demo/demo.ts
@@ -15,36 +15,18 @@ const rdpTarget = {
   securityProtocol: 'auto',
 } satisfies RDPComputerAgentOpt;
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function makeReportFileName() {
-  const timestamp = new Date()
-    .toISOString()
-    .replace(/[:.]/g, '-')
-    .replace('T', '-')
-    .replace('Z', '');
-
-  return `rdp-settings-demo-${timestamp}`;
-}
-
-function assertConfiguredValue(
-  section: string,
-  key: string,
-  value: string | undefined,
-) {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed.startsWith('REPLACE_WITH_')) {
-    throw new Error(
-      `Please update ${section}.${key} in computer/rdp-demo/demo.ts before running the demo.`,
-    );
-  }
-}
-
 function validateDemoConfig() {
-  assertConfiguredValue('rdpTarget', 'host', rdpTarget.host);
-  assertConfiguredValue('rdpTarget', 'password', rdpTarget.password);
+  for (const [key, value] of Object.entries({
+    host: rdpTarget.host,
+    password: rdpTarget.password,
+  })) {
+    const trimmed = value?.trim();
+    if (!trimmed || trimmed.startsWith('REPLACE_WITH_')) {
+      throw new Error(
+        `Please update rdpTarget.${key} in computer/rdp-demo/demo.ts before running the demo.`,
+      );
+    }
+  }
 }
 
 async function waitForRemoteDesktopReady(
@@ -65,7 +47,7 @@ async function waitForRemoteDesktopReady(
       if (attempt === maxAttempts) {
         break;
       }
-      await sleep(delayMs);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
 
@@ -83,7 +65,6 @@ async function main() {
     aiActionContext:
       'You are controlling a remote Windows desktop directly through the RDP protocol. Every screenshot and action comes from the remote machine itself.',
     generateReport: true,
-    reportFileName: makeReportFileName(),
   });
 
   try {

--- a/computer/rdp-demo/demo.ts
+++ b/computer/rdp-demo/demo.ts
@@ -1,0 +1,122 @@
+import {
+  agentForRDPComputer,
+  type RDPComputerAgentOpt,
+} from '@midscene/computer';
+import 'dotenv/config';
+
+const rdpTarget = {
+  host: 'REPLACE_WITH_YOUR_RDP_HOST',
+  port: 3389,
+  username: 'Admin',
+  password: 'REPLACE_WITH_YOUR_RDP_PASSWORD',
+  ignoreCertificate: true,
+  adminSession: false,
+  domain: undefined,
+  securityProtocol: 'auto',
+} satisfies RDPComputerAgentOpt;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeReportFileName() {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace('T', '-')
+    .replace('Z', '');
+
+  return `rdp-settings-demo-${timestamp}`;
+}
+
+function assertConfiguredValue(
+  section: string,
+  key: string,
+  value: string | undefined,
+) {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.startsWith('REPLACE_WITH_')) {
+    throw new Error(
+      `Please update ${section}.${key} in computer/rdp-demo/demo.ts before running the demo.`,
+    );
+  }
+}
+
+function validateDemoConfig() {
+  assertConfiguredValue('rdpTarget', 'host', rdpTarget.host);
+  assertConfiguredValue('rdpTarget', 'password', rdpTarget.password);
+}
+
+async function waitForRemoteDesktopReady(
+  agent: Awaited<ReturnType<typeof agentForRDPComputer>>,
+  maxAttempts = 10,
+  delayMs = 3_000,
+) {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await agent.aiAssert(
+        'The remote screenshot is not a blank white screen. Some visible Windows UI such as the taskbar, desktop icons, the Start menu, or an application window is present.',
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) {
+        break;
+      }
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(
+    `The remote desktop never became visible after ${maxAttempts} attempts.`,
+    { cause: lastError },
+  );
+}
+
+async function main() {
+  validateDemoConfig();
+
+  const agent = await agentForRDPComputer({
+    ...rdpTarget,
+    aiActionContext:
+      'You are controlling a remote Windows desktop directly through the RDP protocol. Every screenshot and action comes from the remote machine itself.',
+    generateReport: true,
+    reportFileName: makeReportFileName(),
+  });
+
+  try {
+    await waitForRemoteDesktopReady(agent);
+
+    await agent.aiAct(
+      'Click the Windows Start button, open the Settings app, then navigate to the Windows Update page. Stop only after the Windows Update page is clearly visible in the remote screenshot.',
+    );
+
+    await agent.aiAssert(
+      'The Windows Update page inside the Settings app is open and visible in the remote screenshot.',
+    );
+
+    const windowsUpdateSummary = await agent.aiQuery<{
+      pageTitle: string;
+      statusSummary: string;
+    }>(
+      '{pageTitle: string, statusSummary: string}, read the visible Windows Update page and return its main page title and the short status summary shown near the top of the page.',
+    );
+
+    console.log('Connected to remote desktop:', rdpTarget.host);
+    console.log('Windows Update page title:', windowsUpdateSummary.pageTitle);
+    console.log('Windows Update status:', windowsUpdateSummary.statusSummary);
+  } finally {
+    await agent.destroy();
+  }
+
+  if (agent.reportFile) {
+    console.log('Report saved to:', agent.reportFile);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/computer/rdp-demo/package.json
+++ b/computer/rdp-demo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@midscene/computer": "1.7.5-beta-20260422015927.0",
+    "@midscene/computer": "latest",
     "dotenv": "^16.4.5",
     "tsx": "4.20.1"
   }

--- a/computer/rdp-demo/package.json
+++ b/computer/rdp-demo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "computer-rdp-demo",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Demo for controlling a remote Windows desktop over RDP with Midscene",
+  "type": "module",
+  "scripts": {
+    "test": "tsx demo.ts"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@midscene/computer": "1.7.5-beta-20260422015927.0",
+    "dotenv": "^16.4.5",
+    "tsx": "4.20.1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new `computer/rdp-demo` that shows how to control a remote Windows desktop directly over the RDP protocol with `@midscene/computer`.
- The demo connects to the remote framebuffer, waits for it to become visible, opens Settings, navigates into Windows Update, extracts a structured summary, and writes a uniquely-named report per run.
- Pinned to `@midscene/computer` `latest` so users always pull the published RDP support.

## Test plan
- [ ] Follow `computer/rdp-demo/README.md`, set the RDP env vars, and run `npm install && npm run test`.
- [ ] Confirm the generated report path is printed and the report opens cleanly.